### PR TITLE
Replace ugettext_lazy with gettext_lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This plugin requires:
 * django-cms: https://github.com/divio/django-cms
 * django-treebeard
 * django-parler
-* aldryn-translation-tools
+
+[//]: # (* aldryn-translation-tools)
 
 Multiple named menus support for DjangoCMS
 

--- a/multimenus/admin.py
+++ b/multimenus/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 
 from aldryn_translation_tools.admin import AllTranslationsMixin
 from parler.admin import TranslatableAdmin
@@ -24,8 +24,8 @@ class MenuItemAdmin(AllTranslationsMixin, TranslatableAdmin, TreeAdmin):
 
     def get_form(self, request, obj=None, **kwargs):
         form_cls = super().get_form(request, obj, **kwargs)
-        form_cls.base_fields['_position'].label = ugettext('Position')
-        form_cls.base_fields['_ref_node_id'].label = ugettext('Relative to')
+        form_cls.base_fields['_position'].label = gettext('Position')
+        form_cls.base_fields['_ref_node_id'].label = gettext('Relative to')
         return form_cls
 
     def get_queryset(self, request):

--- a/multimenus/admin.py
+++ b/multimenus/admin.py
@@ -1,8 +1,13 @@
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.sites.shortcuts import get_current_site
+from django.forms import widgets
+from django.utils.encoding import force_str
 from django.utils.translation import gettext, gettext_lazy as _
 
-from aldryn_translation_tools.admin import AllTranslationsMixin
+from cms.utils.i18n import get_current_language
+from cms.utils.urlutils import admin_reverse
+
 from parler.admin import TranslatableAdmin
 from treebeard.admin import TreeAdmin
 
@@ -10,17 +15,79 @@ from .forms import MenuItemAdminForm
 from .models import MenuItem
 
 
+class AllTranslationsMixin(object):
+
+    @property
+    def media(self):
+        return super(AllTranslationsMixin, self).media + widgets.Media(
+            css={'all': ('css/admin/all-translations-mixin.css',), }
+        )
+
+    def all_translations(self, obj):
+        """
+        Adds a property to the list_display that lists all translations with
+        links directly to their change forms. Includes CSS to style the links
+        to looks like tags with color indicating current language, active and
+        inactive translations.
+
+        A similar capability is in HVAD, and now there is this for
+        Parler-based projects.
+        """
+        available = list(obj.get_available_languages())
+        current = get_current_language()
+        langs = []
+        for code, lang_name in settings.LANGUAGES:
+            classes = ["lang-code", ]
+            title = force_str(lang_name)
+            if code == current:
+                classes += ["current", ]
+            if code in available:
+                classes += ["active", ]
+                title += " (translated)"
+            else:
+                title += " (untranslated)"
+            change_form_url = admin_reverse(
+                '{app_label}_{model_name}_change'.format(
+                    app_label=obj._meta.app_label.lower(),
+                    model_name=obj.__class__.__name__.lower(),
+                ), args=(obj.id,)
+            )
+            link = '<a class="{classes}" href="{url}?language={code}" title="{title}">{code}</a>'.format(
+                classes=' '.join(classes),
+                url=change_form_url,
+                code=code,
+                title=title,
+            )
+            langs.append(link)
+        return ''.join(langs)
+
+    all_translations.short_description = 'Translations'
+    all_translations.allow_tags = True
+
+    def get_list_display(self, request):
+        """
+        Unless the the developer has already placed "all_translations" in the
+        list_display list (presumably specifically where she wants it), append
+        the list of translations to the end.
+        """
+        list_display = super(
+            AllTranslationsMixin, self).get_list_display(request)
+        if 'all_translations' not in list_display:
+            list_display = list(list_display) + ['all_translations', ]
+        return list_display
+
+
 @admin.register(MenuItem)
 class MenuItemAdmin(AllTranslationsMixin, TranslatableAdmin, TreeAdmin):
     fieldsets = (
         (None, {'fields': ('title', 'menu_id')}),
-        (_('Link'), {'fields': ('page', 'url', 'target',  "is_highlighted")}),
+        (_('Link'), {'fields': ('page', 'url', 'target', "is_highlighted")}),
         (_('Tree position'), {'fields': ('_position', '_ref_node_id')}),
     )
     form = MenuItemAdminForm
-    list_display = ('title', 'menu_id', )
-    ordering = ('path', )
-    search_fields = ('translations__title', 'menu_id', )
+    list_display = ('title', 'menu_id',)
+    ordering = ('path',)
+    search_fields = ('translations__title', 'menu_id',)
 
     def get_form(self, request, obj=None, **kwargs):
         form_cls = super().get_form(request, obj, **kwargs)

--- a/multimenus/apps.py
+++ b/multimenus/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MultimenusConfig(AppConfig):

--- a/multimenus/cms_toolbars.py
+++ b/multimenus/cms_toolbars.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from cms.cms_toolbars import ADMIN_MENU_IDENTIFIER, ADMINISTRATION_BREAK
 from cms.toolbar.items import Break

--- a/multimenus/enums.py
+++ b/multimenus/enums.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 TARGET_CHOICES = (

--- a/multimenus/models.py
+++ b/multimenus/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.contrib.sites.models import Site
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from cms.models.fields import PageField
 from parler.models import TranslatableModel, TranslatedFields

--- a/multimenus/static/css/admin/all-translations-mixin.css
+++ b/multimenus/static/css/admin/all-translations-mixin.css
@@ -1,0 +1,23 @@
+a.lang-code {
+    background-color: #BFBFBF; /* hsl(0, 0%, 75%); */
+    border-radius: 3px;
+    color: #fff !important;
+    display: inline-block;
+    font-size: 0.75em;
+    letter-spacing: 0.05em;
+    line-height: 1em;
+    margin-right: 0.25em;
+    padding: 3px;
+    text-decoration: none;
+    text-transform: uppercase;
+}
+a.lang-code.active {
+    background-color: #3B99FC; /* hsl(211, 97%, 61%) */
+}
+a.lang-code.current {
+    background-color: #999999; /* hsl(0, 0%, 60%); */
+    font-weight: bold;
+}
+a.lang-code.current.active {
+    background-color: #3178BE; /* hsl(211, 59%, 48%) */
+}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ REQUIREMENTS = [
     'django-cms',
     'django-treebeard',
     'django-parler',
-    'aldryn-translation-tools',
+    # 'aldryn-translation-tools',
 ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
Replace `ugettext_lazy` with `gettext_lazy` and `ugettext` with `gettext` from `django.utils.translation` in various files.

* **multimenus/admin.py**
  - Replace `ugettext_lazy` with `gettext_lazy`
  - Replace `ugettext` with `gettext`

* **multimenus/apps.py**
  - Replace `ugettext_lazy` with `gettext_lazy`

* **multimenus/cms_toolbars.py**
  - Replace `ugettext_lazy` with `gettext_lazy`

* **multimenus/enums.py**
  - Replace `ugettext` with `gettext`

* **multimenus/models.py**
  - Replace `ugettext_lazy` with `gettext_lazy`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ooppsss60/djangocms-multimenus/pull/2?shareId=5cd55587-7022-4571-a3bc-78302d318307).